### PR TITLE
Edit Readme for use of libfuse2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project is only tested on Linux machines.
 ## Getting started
 Make sure you have fuse installed:
 ```shell
-sudo apt install fuse
+sudo apt install libfuse2
 ```
 Set up your Python virtual environment and activate it:
 ```shell


### PR DESCRIPTION
Instead of using fuse (and possibly breaking your Linux distro), using libfuse2 prevents deletion of ubuntu-session package amongst others.